### PR TITLE
Update flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -43,10 +43,7 @@
             # remeber to bump this hash when your dependencies change.
             #vendorSha256 = pkgs.lib.fakeSha256;
             vendorSha256 =
-              "sha256-zH8N6Bw1I+bFxBiXQtRL/Y2UyE4ix/kdlEsEuwPSZXs=";
-
-            # rename binary from go-lsp to snippets-ls
-            postInstall = "mv $out/bin/go-lsp $out/bin/snippets-ls";
+              "sha256-SbTtKuJxZw+2du+/nwA79ZufgEDS/1qqG2sqqn1x9tM=";
           };
         });
 


### PR DESCRIPTION
The flake is currently broken, this fixes it.

As per the comment the sha should be updated whenever the dependencies change. You can quickly test the package, and if applicable see the updated hash, with:

```console
$ # master
$ nix run ".#" -- -h
error: hash mismatch [...]
    specified: sha256-zH8N6Bw1I+bFxBiXQtRL/Y2UyE4ix/kdlEsEuwPSZXs=
    got:       sha256-SbTtKuJxZw+2du+/nwA79ZufgEDS/1qqG2sqqn1x9tM=

$ # PR
$ nix run ".#" -- -h
<displays help>
```