### PR TITLE
Updated flake.nix && updated home-manager URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ go install github.com/quantonganh/snippets-ls@latest
 
 Don't forget to append `~/go/bin` to your `$PATH`.
 
-### Install via [nix flake](https://nixos.wiki/wiki/Flakes) with [home-manager](https://nix-community.github.io/home-manager/index.html#ch-nix-flakes)
+### Install via [nix flake](https://nixos.wiki/wiki/Flakes) with [home-manager](https://nix-community.github.io/home-manager/index.xhtml#ch-nix-flakes)
 
 Include the following in the `inputs` of `flake.nix` for `home-manager`:
 ```nix

--- a/flake.nix
+++ b/flake.nix
@@ -42,8 +42,8 @@
             # To begin with it is recommended to set this, but one must
             # remeber to bump this hash when your dependencies change.
             #vendorSha256 = pkgs.lib.fakeSha256;
-            vendorSha256 =
-              "sha256-zH8N6Bw1I+bFxBiXQtRL/Y2UyE4ix/kdlEsEuwPSZXs=";
+            vendorHash =
+              "sha256-0FGBtSYKaSjaJlxr8mpXyRKG88ThJCSL3Qutf8gkllw=";
 
             # rename binary from go-lsp to snippets-ls
             postInstall = "mv $out/bin/go-lsp $out/bin/snippets-ls";


### PR DESCRIPTION
The other PR has an outdated hash now, so I made a new PR. `VendorSha256` got changed to `VendorHash`. Also changed the link in `README.md` as said in https://github.com/quantonganh/snippets-ls/pull/8#issuecomment-1852128861. 