### PR TITLE
Fixed build - didn't see that this was removed in other PR

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,12 +41,10 @@
             # it should be "out-of-band" with other tooling (eg. gomod2nix).
             # To begin with it is recommended to set this, but one must
             # remeber to bump this hash when your dependencies change.
-            #vendorSha256 = pkgs.lib.fakeSha256;
-            vendorHash =
+            # buildGoModule expects vendorSha256 and doesn't support vendorHash yet
+            vendorSha256 =
               "sha256-0FGBtSYKaSjaJlxr8mpXyRKG88ThJCSL3Qutf8gkllw=";
 
-            # rename binary from go-lsp to snippets-ls
-            postInstall = "mv $out/bin/go-lsp $out/bin/snippets-ls";
           };
         });
 


### PR DESCRIPTION
Fixed the build - didn't realize that the `postInstall` isn't necessary anymore. I just assumed that changing the hash would do it since it was a simple change. Actually built it this time. 