### PR TITLE
nixpkgs 24.05 compat

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1642609835,
-        "narHash": "sha256-ZwJnV4mdis28u5vH240ec2mrApuEJYJekn23qlTwJ8c=",
+        "lastModified": 1716361217,
+        "narHash": "sha256-mzZDr00WUiUXVm1ujBVv6A0qRd8okaITyUp4ezYRgc4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "77aa71f66fd05d9e7b7d1c084865d703a8008ab7",
+        "rev": "46397778ef1f73414b03ed553a3368f0e7e33c2f",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-21.11",
+        "ref": "nixos-23.11",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
             # it should be "out-of-band" with other tooling (eg. gomod2nix).
             # To begin with it is recommended to set this, but one must
             # remember to bump this hash when your dependencies change.
-            vendorSha256 =
+            vendorHash =
               "sha256-SbTtKuJxZw+2du+/nwA79ZufgEDS/1qqG2sqqn1x9tM=";
 
           };

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
             # remeber to bump this hash when your dependencies change.
             # buildGoModule expects vendorSha256 and doesn't support vendorHash yet
             vendorSha256 =
-              "sha256-0FGBtSYKaSjaJlxr8mpXyRKG88ThJCSL3Qutf8gkllw=";
+              "sha256-SbTtKuJxZw+2du+/nwA79ZufgEDS/1qqG2sqqn1x9tM=";
 
           };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Snippet LSP for helix";
 
   # nixpkgs version to use
-  inputs.nixpkgs.url = "nixpkgs/nixos-21.11";
+  inputs.nixpkgs.url = "nixpkgs/nixos-23.11";
 
   outputs = { self, nixpkgs }:
     let
@@ -40,8 +40,7 @@
             # mechanisms to tell you what the hash should be or determine what
             # it should be "out-of-band" with other tooling (eg. gomod2nix).
             # To begin with it is recommended to set this, but one must
-            # remeber to bump this hash when your dependencies change.
-            # buildGoModule expects vendorSha256 and doesn't support vendorHash yet
+            # remember to bump this hash when your dependencies change.
             vendorSha256 =
               "sha256-SbTtKuJxZw+2du+/nwA79ZufgEDS/1qqG2sqqn1x9tM=";
 


### PR DESCRIPTION
Folks with an input like the following will have started seeing deprecation notices a little while ago:

```nix
snippets-ls = {
  url = "github:quantonganh/snippets-ls";
  inputs.nixpkgs.follows = "nixpkgs";
};
```

As of nixpkgs 24.05, which releases in a few days, this is a hard error.

Tested with:

```console
$ nix run ".#" -- -h
```

And also by updating my own system flake to point to my branch.