### PR TITLE
Update Nix lockfile and vendorHash

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716361217,
-        "narHash": "sha256-mzZDr00WUiUXVm1ujBVv6A0qRd8okaITyUp4ezYRgc4=",
+        "lastModified": 1718447546,
+        "narHash": "sha256-JHuXsrC9pr4kA4n7LuuPfWFJUVlDBVJ1TXDVpHEuUgM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46397778ef1f73414b03ed553a3368f0e7e33c2f",
+        "rev": "842253bf992c3a7157b67600c2857193f126563a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
             # To begin with it is recommended to set this, but one must
             # remember to bump this hash when your dependencies change.
             vendorHash =
-              "sha256-SbTtKuJxZw+2du+/nwA79ZufgEDS/1qqG2sqqn1x9tM=";
+              "sha256-0FGBtSYKaSjaJlxr8mpXyRKG88ThJCSL3Qutf8gkllw=";
 
           };
         });

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,14 @@
             vendorHash =
               "sha256-0FGBtSYKaSjaJlxr8mpXyRKG88ThJCSL3Qutf8gkllw=";
 
+
+            meta = with pkgs.lib; {
+              description = "A simple language server to insert snippets into Helix";
+              homepage = "https://github.com/quantonganh/snippets-ls";
+              license = licenses.mit;
+              maintainers = with maintainers; [bddvlpr];
+              mainProgram = "snippets-ls";
+            };
           };
         });
 


### PR DESCRIPTION
Currently, the latest commit fails to build in Nix due to the dependencies having changed over time without updating the vendor hash.